### PR TITLE
Update plugin to match method renames.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@ class ClipboardPlugin(Plugin):
                 }
             }
         })
-        self._inject()
+        self.inject()
 
     def monitor(self, args: list = None) -> None:
         """


### PR DESCRIPTION
A method rename occurred in https://github.com/sensepost/objection/commit/57017fb31eb21b9d1ca8644ced6c83e94ed1bdf7, which this PR fixes to keep this example plugin up to date.